### PR TITLE
Fix NullPointerException in ClipboardListener

### DIFF
--- a/src/android/plugin/src/main/java/plugin/pasteboard/ClipboardListener.java
+++ b/src/android/plugin/src/main/java/plugin/pasteboard/ClipboardListener.java
@@ -28,8 +28,11 @@ public class ClipboardListener {
         // If the Clipboard contains data, save it to shared
         if (clipboardManager.hasPrimaryClip()) {
             android.content.ClipData clipData = clipboardManager.getPrimaryClip();
-            android.content.ClipData.Item item = clipData.getItemAt(0);
-            shared.setCurrentPasteboardItem(shared.ApiLevel11.coerceToString(context, item));
+            // Check if clipData is not null
+            if (clipData != null) {
+                android.content.ClipData.Item item = clipData.getItemAt(0);
+                shared.setCurrentPasteboardItem(shared.ApiLevel11.coerceToString(context, item));
+            }
         }
     }
 


### PR DESCRIPTION
### Issue
Firebase Crashlytics shows crashes on some Android devices due to a `NullPointerException` in `plugin.pasteboard`. It happens when `clipboardManager.getPrimaryClip()` returns `null` but `hasPrimaryClip()` is `true`.

### Fix
Added `if (clipData != null)` in `ClipboardListener.java` to skip processing if `clipData` is `null`.

### Impact
- Prevents crashes when `clipData` is `null`.
- No change if `clipData` is not `null`.

Please review and merge to fix production crashes.